### PR TITLE
Update configuration for Nginx

### DIFF
--- a/docs/start/web-servers.md
+++ b/docs/start/web-servers.md
@@ -25,7 +25,7 @@ AllowOverride All
 The nginx configuration file should contain this code (along with other settings you may need) in your `location` block:
 
 {% highlight text %}
-try_files $uri $uri/ /index.php?$args;
+try_files $uri $uri/ /index.php?$query_string;
 {% endhighlight %}
 
 This assumes that Slim's `index.php` is in the root folder of your project (www root).


### PR DESCRIPTION
If $args is used instead of $query_string, parameters passed like: url.com/sompage/?parameter=test cannot be interpreted.

Ref: http://help.slimframework.com/discussions/problems/4204-cannot-get-url-parametersquery-string
