### PR TITLE
Update router.md with the correct way to retrieve the router

### DIFF
--- a/docs/objects/router.md
+++ b/docs/objects/router.md
@@ -204,7 +204,7 @@ $app->get('/hello/{name}', function ($request, $response, $args) {
 You can generate a URL for this named route with the application router's `pathFor()`  method.
 
 {% highlight php %}
-echo $app['router']->pathFor('hello', [
+echo $app->getContainer()->get('router')->pathFor('hello', [
     'name' => 'Josh'
 ]);
 // Outputs "/hello/Josh"

--- a/docs/objects/router.md
+++ b/docs/objects/router.md
@@ -204,7 +204,7 @@ $app->get('/hello/{name}', function ($request, $response, $args) {
 You can generate a URL for this named route with the application router's `pathFor()`  method.
 
 {% highlight php %}
-echo $app->getContainer()->get('router')->pathFor('hello', [
+echo $app->router->pathFor('hello', [
     'name' => 'Josh'
 ]);
 // Outputs "/hello/Josh"


### PR DESCRIPTION
In the documentation for Slim 3.0, paragraph "Route Names", you are using the following example:

echo $app['router']->pathFor('hello', [ 'name' => 'Josh' ]); // Outputs "/hello/Josh"

Do you mean by any chance

$app->getContainer()->get('router')->pathFor('hello', [ 'name' => 'Josh' ])

? Because you can't treat the Slim\App object as an array, and I believe this is the correct way to retrieve the router having a reference to the App.

Thanks!
