### PR TITLE
name -> setName

### DIFF
--- a/docs/features/templates.md
+++ b/docs/features/templates.md
@@ -63,7 +63,7 @@ $app->get('/hello/{name}', function ($request, $response, $args) {
     return $this->view->render($response, 'profile.html', [
         'name' => $args['name']
     ]);
-})->name('profile');
+})->setName('profile');
 
 // Run app
 $app->run();


### PR DESCRIPTION
Minor error in the documentation. Name of a route is set with `setName`, not `name`.
