### PR TITLE
Add link to v3 documentation on homepage in flash message

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,8 @@ description: Slim is a PHP micro framework that helps you quickly write simple y
 <div class="row">
     <div class="col-md-12">
         <div class="alert alert-info">
-            Slim 3.0 RC 1 has been released. <a href="/2015/09/08/slim3-rc1.html">Details here</a>!
+            Slim 3.0 RC 1 has been released. <a href="/2015/09/08/slim3-rc1.html">Details here</a>! 
+            Documentation is available <a href="/docs/">here</a>.
         </div>
         <p class="lead">
             Slim is a PHP micro framework that helps you quickly write simple yet powerful web applications and APIs.


### PR DESCRIPTION
I had a hard time finding the link to the v3 documentation as it's not obvious from the home page. I thought this would be useful.
