### PR TITLE
Added  a return value to the container cache statement

### DIFF
--- a/docs/features/caching.md
+++ b/docs/features/caching.md
@@ -24,7 +24,7 @@ middleware. You should add both to your application like this:
 // Register service provider with the container
 $container = new \Slim\Container;
 $container['cache'] = function () {
-    new \Slim\HttpCache\CacheProvider();
+    return new \Slim\HttpCache\CacheProvider();
 };
 
 // Add middleware to the application


### PR DESCRIPTION
This only worked for me if I returned out of the container - following an example in @akrabats skeleton so I thought I would update the docs - it makes sense to return but I am unsure whether it is always necessary?
