### PR TITLE
Add missing require of Composer's autoloader in the example

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@ description: Slim is a PHP micro framework that helps you quickly write simple y
 use \Psr\Http\Message\ServerRequestInterface as Request;
 use \Psr\Http\Message\ResponseInterface as Response;
 
+require 'vendor/autoload.php';
+
 $app = new \Slim\App;
 $app-&gt;get('/hello/{name}', function (Request $request, Response $response) {
     $name = $request->getAttribute('name');


### PR DESCRIPTION
Sorry I forgot about that in #80 and now that it was merged I just remembered about it.
