### PR TITLE
Add link to Slim 2 docs to Docs index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,12 @@
 title: Documentation
 ---
 
+<div class="alert alert-info">
+    <p>
+        This documentation is for <strong>Slim 3</strong>. The Slim 2 documentation is available at <a href="http://docs.slimframework.com/">docs.slimframework.com</a>.
+    </p>
+</div>
+
 ## Welcome
 
 Slim is a PHP micro framework that helps you


### PR DESCRIPTION
Lots of people still need to access the Slim 2 documentation, but it's difficult (impossible?) to find on the current web site. I think a pointer to the old docs is a good idea.
