### PR TITLE
Update description of getParsedBody in relation to JSON

### DIFF
--- a/docs/objects/request.md
+++ b/docs/objects/request.md
@@ -234,7 +234,7 @@ $parsedBody = $request->getParsedBody();
 <figcaption>Figure 9: Parse HTTP request body into native PHP format</figcaption>
 </figure>
 
-* JSON requests are converted into a PHP object with `json_decode($input)`.
+* JSON requests are converted into associative arrays with `json_decode($input, true)`.
 * XML requests are converted into a `SimpleXMLElement` with `simplexml_load_string($input)`.
 * URL-encoded requests are converted into a PHP array with `parse_str($input)`.
 


### PR DESCRIPTION
The docs say that JSON requests are converted to PHP Objects, but the code has `json_decode,($input, true)` where the second parameter causes the function to return an array instead of an object.

[PHP docs for json_decode](https://secure.php.net/manual/en/function.json-decode.php)
[Slim Request Class](https://github.com/slimphp/Slim/blob/3.x/Slim/Http/Request.php#L190)
