### PR TITLE
Make error handling info easier to find

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,7 +51,7 @@ defaults:
             - [/docs/objects/router.md#route-middleware, Middleware]
         - title: Error Handling
           items:
-            - [/docs/handlers/error.md, 500 Server Error]
+            - [/docs/handlers/error.md, Error Handlers]
             - [/docs/handlers/not-found.md, 404 Not Found]
             - [/docs/handlers/not-allowed.md, 405 Not Allowed]
         - title: Cook book

--- a/docs/handlers/error.md
+++ b/docs/handlers/error.md
@@ -1,5 +1,5 @@
 ---
-title: 500 System Error Handler
+title: System Error Handler
 ---
 
 Things go wrong. You can't predict errors, but you can anticipate them. Each Slim Framework application has an error handler that receives all uncaught PHP exceptions. This error handler also receives the current HTTP request and response objects, too. The error handler must prepare and return an appropriate Response object to be returned to the HTTP client.


### PR DESCRIPTION
This page has awesome docs but the "500" title was confusing as it was
handling an exception so I knew it wasn't a 500 error I was looking for
help with.  Hoping this change makes the information easier for everyone
to find.
