### PR TITLE
Add cookbook page for getting current route

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,6 +58,7 @@ defaults:
           items:
             - [/docs/cookbook/route-patterns.md, Trailing / in routes]
             - [/docs/cookbook/ip-address.md, Retrieving IP address]
+            - [/docs/cookbook/middleware-patterns.md, Retrieving Current Route]
         - title: Add Ons
           items:
             - [/docs/features/templates.md, Templates]

--- a/docs/cookbook/middleware-patterns.md
+++ b/docs/cookbook/middleware-patterns.md
@@ -1,0 +1,37 @@
+---
+title: Retrieving Current Route
+---
+
+If you ever need to get access to the current route within your application all you have to do is call the request class' getAttribute method with an argument of 'route' and it will return a an instance of the Slim\Route class.
+
+From there you can get the route's name by using getName() or get the methods supported by this route via getMethods(), etc.
+
+ Note: If you need to access the route from within your middleware you must set 'determineRouteBeforeAppMiddleware' to true in your configuration otherwise getAttribute('route') will return null.
+
+Example:
+{% highlight php %}
+use Slim\Http\Request;
+use Slim\Http\Response;
+use Slim\App;
+
+$app = new App([
+    'settings' => [
+        // Only set this if you need access to route within middleware
+        'determineRouteBeforeAppMiddleware' => true
+    ]
+])
+
+// routes...
+
+$app->add(function (Request $request, Response $response, callable $next) {
+    $route = $request->getAttribute('route');
+    $name = $route->getName();
+    $group = $route->getGroup();
+    $methods = $route->getMethods();
+    $arguments = $route->getArguments();
+
+    // do something with that information
+
+    return $next($request, $response);
+});
+{% endhighlight %}


### PR DESCRIPTION
Created middleware-patterns.md and showed how to access current route
from middleware or anywhere else in the application. Created example to
go along with it as well.

Issue [#1719](https://github.com/slimphp/Slim/issues/1719#issuecomment-168651102) on main repo
