### PR TITLE
fix example for urlFor

### DIFF
--- a/docs/objects/router.md
+++ b/docs/objects/router.md
@@ -225,7 +225,7 @@ $app->get('/hello/{name}', function ($request, $response, $args) {
 You can generate a URL for this named route with the application router's `pathFor()`  method.
 
 {% highlight php %}
-echo $app->router->pathFor('hello', [
+echo $app->getContainer()->get('router')->pathFor('hello', [
     'name' => 'Josh'
 ]);
 // Outputs "/hello/Josh"


### PR DESCRIPTION
Updated the example for `urlFor`. Now Router object need to get from the container.
