### PR TITLE
Fix variable name $newRespose -> $newResponse

### DIFF
--- a/docs/start/upgrade.md
+++ b/docs/start/upgrade.md
@@ -58,8 +58,8 @@ use Psr\Http\Message\RequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 
 $app->add(function (Request $req,  Response $res, callable $next) {
-    // Do stuff before passing a long
-    $newRespose = $next($req, $res);
+    // Do stuff before passing along
+    $newResponse = $next($req, $res);
     // Do stuff after route is rendered
     return $newResponse; // continue
 });
@@ -76,8 +76,8 @@ use Psr\Http\Message\ResponseInterface as Response;
 class Middleware
 {
     function __invoke(Request $req,  Response $res, callable $next) {
-        // Do stuff before passing a long
-        $newRespose = $next($req, $res);
+        // Do stuff before passing along
+        $newResponse = $next($req, $res);
         // Do stuff after route is rendered
         return $newResponse; // continue
     }


### PR DESCRIPTION
In the Middleware sample code $newRespose is assigned the result of $next() but it's trying to return $newResponse. Note that the 'n' is missing and different.
