### PR TITLE
Update router.md

### DIFF
--- a/docs/objects/router.md
+++ b/docs/objects/router.md
@@ -222,7 +222,7 @@ $app->get('/news[/{year}[/{month}]]', function ($request, $response, $args) {
 For "Unlimited" optional parameters, you can do this:
 
 {% highlight php %}
-$app->get('/news[/{params.*}]', function ($request, $response, $args) {
+$app->get('/news[/{params:.*}]', function ($request, $response, $args) {
     $params = explode('/', $request->getAttribute('params'));
 
     // $params is an array of all the optional segments


### PR DESCRIPTION
The ":" character was missing in the "Unlimited" optional parameters example.
