### PR TITLE
Update composer installation instructions

### DIFF
--- a/docs/start/installation.md
+++ b/docs/start/installation.md
@@ -28,9 +28,4 @@ require 'vendor/autoload.php';
 
 ## How to Install Composer
 
-Don't have Composer? It's easy to install. The following bash command
-downloads Composer and moves it into your `/usr/local/bin` directory.
-
-{% highlight bash %}
-curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-{% endhighlight %}
+Don't have Composer? It's easy to install by following the instructions on their [download](https://getcomposer.org/download/) page.


### PR DESCRIPTION
The composer [installation](https://getcomposer.org/download/) instructions changed. Cannot put the instructions in the docs since the hash will change on every update of composer, so instead a link to the download page.
