### PR TITLE
Point the "PHP-DI" link to the "Slim integration" docs

### DIFF
--- a/docs/concepts/di.md
+++ b/docs/concepts/di.md
@@ -5,7 +5,7 @@ title: Dependency Container
 Slim uses a dependency container to prepare, manage, and inject application
 dependencies. Slim supports containers that implement the [Container-Interop](https://github.com/container-interop/container-interop) interface. You can use Slim's built-in container (based on [Pimple](http://pimple.sensiolabs.org/))
 or third-party containers like [Acclimate](https://github.com/jeremeamia/acclimate-container)
-or [PHP-DI](http://php-di.org/).
+or [PHP-DI](http://php-di.org/doc/frameworks/slim.html).
 
 ## How to use the container
 


### PR DESCRIPTION
I've changed the link to PHP-DI's website to point to the documentation of the "PHP-DI - Slim bridge" directly.

Do you think there is something better that could be done? Suggestions welcome.
