### PR TITLE
Add info on checking if a service exists

### DIFF
--- a/docs/concepts/di.md
+++ b/docs/concepts/di.md
@@ -57,6 +57,28 @@ $app->get('/foo', function ($req, $res, $args) {
 });
 {% endhighlight %}
 
+To test if a service exists in the container before using it, use the `has()` method, like this:
+
+{% highlight php %}
+/**
+ * Example GET route
+ *
+ * @param  \Psr\Http\Message\ServerRequestInterface $req  PSR7 request
+ * @param  \Psr\Http\Message\ResponseInterface      $res  PSR7 response
+ * @param  array                                    $args Route parameters
+ *
+ * @return \Psr\Http\Message\ResponseInterface
+ */
+$app->get('/foo', function ($req, $res, $args) {
+    if($this->has('myService')) {
+        $myService = $this->myService;
+    }
+
+    return $res;
+});
+{% endhighlight %}
+
+
 Slim uses `__get()` and `__isset()` magic methods that defer to the application's
 container for all properties that do not already exist on the application instance.
 


### PR DESCRIPTION
When accessing a service that does not exist in a container (in my case, it was an optional dependency), a fatal error occurs.  Added the example to the docs of how to check for it before using it.
