### PR TITLE
gh-120 reinserted environment page in navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,6 +77,7 @@ defaults:
             - [/docs/cookbook/ip-address.md, Retrieving IP address]
             - [/docs/cookbook/retrieving-current-route.md, Retrieving Current Route]
             - [/docs/cookbook/database-eloquent.md, Using Eloquent with Slim]
+            - [/docs/cookbook/environment.md, Getting and Mocking the Environment]            
         - title: Add Ons
           items:
             - [/docs/features/templates.md, Templates]

--- a/docs/cookbook/environment.md
+++ b/docs/cookbook/environment.md
@@ -1,5 +1,5 @@
 ---
-title: Environment
+title: Getting and Mocking the Environment
 ---
 
 The Environment object encapsulates the `$_SERVER` superglobal array and decouples the Slim application from the PHP global environment. Decoupling the Slim application from the PHP global environment lets us create HTTP requests that may (or may not) resemble the global environment. This is particuarly useful for unit testing and initiating sub-requests. You can fetch the current Environment object anywhere in your Slim application like this:


### PR DESCRIPTION
Moved Environment page to the Cookbook section, because it doesn't look as imported as for instance the Request, Response and Body sections.  
