### PR TITLE
Update trailing slash middleware implementation

### DIFF
--- a/docs/cookbook/route-patterns.md
+++ b/docs/cookbook/route-patterns.md
@@ -4,7 +4,9 @@ title: Trailing / in route patterns
 
 Slim treats a URL pattern with a trailing slash as different to one without. That is, `/user` and `/user/` are different and so can have different callbacks attached.
 
-If you want to redirect all URLs that end in a `/` to the non-trailing `/` equivalent, then you can add this middleware:
+For GET requests a permanent redirect is fine, but for other request methods like POST or PUT the browser will send the second request with the GET method. To avoid this you simply need to remove the trailing slash and pass the manipulated url to the next middelware.
+
+If you want to redirect/rewrite all URLs that end in a `/` to the non-trailing `/` equivalent, then you can add this middleware:
 
 {% highlight php %}
 use Psr\Http\Message\RequestInterface as Request;
@@ -17,7 +19,13 @@ $app->add(function (Request $request, Response $response, callable $next) {
         // permanently redirect paths with a trailing slash
         // to their non-trailing counterpart
         $uri = $uri->withPath(substr($path, 0, -1));
-        return $response->withRedirect((string)$uri, 301);
+        
+        if($request->getMethod() == 'GET') {
+            return $response->withRedirect((string)$uri, 301);
+        }
+        else {
+            return $next($request->withUri($uri), $response);
+        }
     }
 
     return $next($request, $response);


### PR DESCRIPTION
to be compatible with all request methods the trailing slash middleware needs to be implemented with either a redirect or a rewrite of the url.
