### PR TITLE
Fix broken link to Twig documentation

### DIFF
--- a/docs/features/templates.md
+++ b/docs/features/templates.md
@@ -56,7 +56,7 @@ $container['view'] = function ($container) {
 <figcaption>Figure 2: Register slim/twig-view component with container.</figcaption>
 </figure>
 
-Note : "cache" could be set to false to disable it, see also 'auto_reload' option, useful in development environment. For more information, see [Twig environment options](http://twig.sensiolabs.org/api/master/Twig_Environment.html#method___construct)
+Note : "cache" could be set to false to disable it, see also 'auto_reload' option, useful in development environment. For more information, see [Twig environment options](http://twig.sensiolabs.org/doc/2.x/api.html#environment-options)
 
 Now you can use the `slim/twig-view` component service inside an app route
 to render a template and write it to a PSR 7 Response object like this:


### PR DESCRIPTION
Looks like SensioLabs may have moved some things around a bit. 