### PR TITLE
Fix available middleware section links markdown

### DIFF
--- a/docs/concepts/middleware.md
+++ b/docs/concepts/middleware.md
@@ -232,6 +232,6 @@ $foo = $request->getAttribute('foo');
 
 You may find a PSR 7 Middleware class already written that will satisfy your needs. Here are a few unofficial lists to search.
 
-* (oscarotero/psr7-middlewares)[https://github.com/oscarotero/psr7-middlewares]
-* (Middleware for Slim Framework v3.x wiki)[https://github.com/slimphp/Slim/wiki/Middleware-for-Slim-Framework-v3.x]
-* (lalop/awesome-psr7)[https://github.com/lalop/awesome-psr7]
+* [oscarotero/psr7-middlewares](https://github.com/oscarotero/psr7-middlewares)
+* [Middleware for Slim Framework v3.x wiki](https://github.com/slimphp/Slim/wiki/Middleware-for-Slim-Framework-v3.x)
+* [lalop/awesome-psr7](https://github.com/lalop/awesome-psr7)


### PR DESCRIPTION
The links were not clickable because of a wrong markdown syntax.