### PR TITLE
Example of route group with empty pattern

### DIFF
--- a/docs/objects/router.md
+++ b/docs/objects/router.md
@@ -287,6 +287,19 @@ $app->group('/users/{id:[0-9]+}', function () {
 });
 ```
 
+The group pattern can be empty, enabling the logical grouping of routes that do not share a common pattern.
+
+```php
+$app->group('', function() {
+    $this->get('/billing', function ($request, $response, $args) {
+        // Route for /billing
+    });
+    $this->get('/invoice/{id:[0-9]+}', function ($request, $response, $args) {
+        // Route for /invoice/{id:[0-9]+}
+    });
+})->add( new SharedMiddleware() );
+```
+
 Note inside the group closure, `$this` is used instead of `$app`. Slim binds the closure to the application instance for you, just like it is the case with route callback binds with container instance.
 
 * inside group closure, `$this` is bound to the instance of `Slim\App`


### PR DESCRIPTION
Adds an example of using an empty route pattern on a group to enable routes that don't share the same stem path to be grouped. This functionality is useful for applying middleware to a group of routes, but isn't otherwise mentioned in the docs.