### PR TITLE
🚑 Remove Goodies link to stickermule because the marketplace has clos…

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -50,7 +50,6 @@
                         <li{% if page.url contains "/docs" %} class="active"{% endif %}><a href="/docs">User Guide</a></li>
                         <li><a href="http://discourse.slimframework.com/">Support</a></li>
                         <li{% if page.url contains "/contribute" %} class="active"{% endif %}><a href="/contribute">Contribute</a></li>
-                        <li><a href="https://www.stickermule.com/user/1070648464/stickers" target="_blank"><i class="fa fa-heart"></i> Goodies</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
…ed :(

Noticed the Goodies link was redirected back to the main stickermule page so I did some digging and found out they have closed the marketplace: https://twitter.com/stickermule/status/960959199910883329