### PR TITLE
 Fix constant redirects to docs/v3/v3/v3/..

### DIFF
--- a/404.html
+++ b/404.html
@@ -10,7 +10,7 @@ permalink: /404.html
 Page not found! :(
 
 <script>
-    if( window.location.pathname.indexOf('/docs/') >= 0){
+    if (window.location.pathname.indexOf('/docs/') >= 0 && window.location.pathname.indexOf('/v3/') <= 0) {
         window.location = '/docs/v3' + window.location.pathname.substr(5);
     }
 </script>


### PR DESCRIPTION
Here's a solution that seems to behave as we'd want it to.

`/docs/concepts/di.html` -> is a good URL should redirect to `/docs/v3/concepts/di.html` This is working with the change.

`/docs/bad.html` -> is a bad URL should show 404, we redirect to `/docs/v3/bad.html` but still show a 404 because it's not an actual URL. This is working with the change.

Resolves #286