### PR TITLE
Update syntax for container lookup.

### DIFF
--- a/docs/v3/features/templates.md
+++ b/docs/v3/features/templates.md
@@ -47,8 +47,8 @@ $container['view'] = function ($container) {
     ]);
 
     // Instantiate and add Slim specific extension
-    $basePath = rtrim(str_ireplace('index.php', '', $container['request']->getUri()->getBasePath()), '/');
-    $view->addExtension(new Slim\Views\TwigExtension($container['router'], $basePath));
+    $basePath = rtrim(str_ireplace('index.php', '', $container->get('request')->getUri()->getBasePath()), '/');
+    $view->addExtension(new Slim\Views\TwigExtension($container->get('router'), $basePath));
 
     return $view;
 };


### PR DESCRIPTION
Now `$container[something]` only return `null` for services.
We should use `$container->get(something)`.