### PR TITLE
Update figure 2: Register slim/twig-view component with container in the templates.md

### DIFF
--- a/docs/v3/features/templates.md
+++ b/docs/v3/features/templates.md
@@ -47,8 +47,9 @@ $container['view'] = function ($container) {
     ]);
 
     // Instantiate and add Slim specific extension
-    $basePath = rtrim(str_ireplace('index.php', '', $container->get('request')->getUri()->getBasePath()), '/');
-    $view->addExtension(new Slim\Views\TwigExtension($container->get('router'), $basePath));
+    $router = $container->get('router');
+    $uri = \Slim\Http\Uri::createFromEnvironment(new \Slim\Http\Environment($_SERVER));
+    $view->addExtension(new Slim\Views\TwigExtension($router, $uri));
 
     return $view;
 };


### PR DESCRIPTION
In the code sample, register the `view `component as a service on the Slim app’s container. It will okay if you don't call the method `isCurrentPath`.
```
$basePath = rtrim(str_ireplace('index.php', '', $container->get('request')->getUri()->getBasePath()), '/');
$view->addExtension(new Slim\Views\TwigExtension($container->get('router'), $basePath));
```
But when call the method `isCurrentPath()` in twig file, it had an error "Call to a member function getBasePath() on string". Because `$basePath` is the String, when passing it to TwigExtension then `$uri` of TwigExtension will be String and when call method `isCurrentPath()` it not working.

Solution
Update the second parameter when Instantiate and add TwigExtension to Twig-View.
```
$router = $container->get('router');
$uri = \Slim\Http\Uri::createFromEnvironment(new \Slim\Http\Environment($_SERVER));
$view->addExtension(new \Slim\Views\TwigExtension($router, $uri));
```
