### PR TITLE
Remove 'debug' configuration option from example

### DIFF
--- a/docs/v3/objects/application.md
+++ b/docs/v3/objects/application.md
@@ -70,8 +70,7 @@ you can use the `replace` method on the settings container. For example:
 $settings = $container->get('settings');
 $settings->replace([
         'displayErrorDetails' => true,
-        'determineRouteBeforeAppMiddleware' => true,
-        'debug' => true
+        'determineRouteBeforeAppMiddleware' => true
     ]);
 ]);
 ```


### PR DESCRIPTION
My guess is the 'debug' parameter is a leftover from V2. It has no meaning in V3, as far as I can tell. Removing it from this example to avoid confusing people coming across this documentation and assuming it does anything. Not that that ever happened to anyone 😳