### PR TITLE
Edit autoload path

### DIFF
--- a/docs/v3/tutorial/first-app.md
+++ b/docs/v3/tutorial/first-app.md
@@ -48,7 +48,7 @@ There's a really excellent and minimal example of an `index.php` for Slim Framew
 use \Psr\Http\Message\ServerRequestInterface as Request;
 use \Psr\Http\Message\ResponseInterface as Response;
 
-require '../vendor/autoload.php';
+require '../../vendor/autoload.php';
 
 $app = new \Slim\App;
 $app->get('/hello/{name}', function (Request $request, Response $response, array $args) {


### PR DESCRIPTION
If we strictly follow `https://www.slimframework.com/docs/v3/tutorial/first-app.html` tutorial and launch `php -S localhost:8080` from `src/public` we receive `Failed opening required '../vendor/autoload.php'` error since the file is located one level higher