### PR TITLE
Fix minor spelling errors in v3 site and blog

### DIFF
--- a/_posts/2011-09-15-hello-world.md
+++ b/_posts/2011-09-15-hello-world.md
@@ -4,7 +4,7 @@ description: Build a simple Hello World application with the Slim Framework for 
 layout: post
 ---
 
-This tutorial demonstrates the typical process for writing a Slim Framework application. The Slim Framework uses the front controller pattern to send all HTTP requests through a single file — usually `index.php`. By default, Slim comes with a `.htaccess` file for use with the Apache web server. You'll typically intitialize your app, define your routes, and run your app in the ``index.php`.
+This tutorial demonstrates the typical process for writing a Slim Framework application. The Slim Framework uses the front controller pattern to send all HTTP requests through a single file — usually `index.php`. By default, Slim comes with a `.htaccess` file for use with the Apache web server. You'll typically initialize your app, define your routes, and run your app in the ``index.php`.
 
 ## Step 1: Initialize your app
 

--- a/_posts/2012-08-27-version-166.md
+++ b/_posts/2012-08-27-version-166.md
@@ -19,7 +19,7 @@ Before version 1.6.6, Slim had a large global namespace footprint. Version 1.6.6
 
 * Slim requires libmcrypt;
 * Your existing `error_reporting` setting will be used;
-* Slim’s error handler is used only within `Slim::run`; aftwerward, the previous error handler is restored.
+* Slim’s error handler is used only within `Slim::run`; afterward, the previous error handler is restored.
 
 Visit this URL to view the relevant changes to the source code:
 

--- a/_posts/2015-02-11-whats-up-with-version-3.md
+++ b/_posts/2015-02-11-whats-up-with-version-3.md
@@ -81,7 +81,7 @@ This branch name change has not happened yet, but it will before the 3.0 release
 
 ### Road map
 
-I will soon establish a new Road Map on the project's GitHub wiki. I will announce this as soon as it is avialable.
+I will soon establish a new Road Map on the project's GitHub wiki. I will announce this as soon as it is available.
 
 ### Unit tests
 

--- a/_posts/2015-07-03-slim3-beta1.md
+++ b/_posts/2015-07-03-slim3-beta1.md
@@ -61,4 +61,4 @@ The framework codebase is much simpler. Previously, the `\Slim\App` class contai
 
 ## What's next?
 
-We believe that Slim 3 beta 1 contains all the key changes we envision for version 3.0 and so we are now contentrating on stability and bug fixes. When we are happy, we will release the first stable version of 3.0.
+We believe that Slim 3 beta 1 contains all the key changes we envision for version 3.0 and so we are now concentrating on stability and bug fixes. When we are happy, we will release the first stable version of 3.0.

--- a/_posts/2015-08-10-slim3-beta2.md
+++ b/_posts/2015-08-10-slim3-beta2.md
@@ -18,7 +18,7 @@ The full list of changes is [here](https://github.com/slimphp/Slim/issues?q=mile
 
 For details on the what's new in Slim 3, please see this [article about 3.0 beta 1](http://www.slimframework.com/2015/07/03/slim3-beta1.html).
 
-We really want Slim 3 to be a stable and easy to use framework. Please test it and [report](https://github.com/slimphp/Slim/issues) all issues that you find. Also note that while we hope that we won't need to change any function signatures, we aren't promising that we'll keep BC before the stable version of 3.0 is releaed.
+We really want Slim 3 to be a stable and easy to use framework. Please test it and [report](https://github.com/slimphp/Slim/issues) all issues that you find. Also note that while we hope that we won't need to change any function signatures, we aren't promising that we'll keep BC before the stable version of 3.0 is released.
 
 To get started, you can follow the [installation instructions](https://github.com/slimphp/Slim/tree/3.x#installation) or use [Rob Allen](http://akrabat.com)'s [skeleton application](http://akrabat.com/a-slim3-skeleton/).
 

--- a/_posts/2015-11-29-slim3-rc3.md
+++ b/_posts/2015-11-29-slim3-rc3.md
@@ -16,7 +16,7 @@ We have now released the [third release candidate of Slim 3](https://github.com/
 These are the BC breaks since RC2:
 
 * [#1631](https://github.com/slimphp/Slim/pull/1631) - The route callable is now bound to the Container rather than to the App to be consistent with middleware binding. This means that if you are using `$this->subRequest` then you now need to `use ($app)` and then `$app->subRequest(…)`. Also if you were using `$this->getContainer()->get(…)`, you need to change this to `$this->get(…)`. Note that using `$this->foo` to retrieve a service from the container continues to work.
-* [#1626](https://github.com/slimphp/Slim/pull/1626) - Route paths are now simply concatentated with no magic. This may affect the way route groups were previously set up, but from now on, it's very predictable.
+* [#1626](https://github.com/slimphp/Slim/pull/1626) - Route paths are now simply concatenated with no magic. This may affect the way route groups were previously set up, but from now on, it's very predictable.
 * [#1625](https://github.com/slimphp/Slim/pull/1625) - Group middleware is now executed before the route's middleware as you would expect. See issue [#1622](https://github.com/slimphp/Slim/issues/1622) for details.
 
 The full list of changes is [here](https://github.com/slimphp/Slim/issues?q=milestone%3A%223.0.0+RC3%22+is%3Apr)

--- a/_posts/2015-12-07-slim-3.md
+++ b/_posts/2015-12-07-slim-3.md
@@ -51,7 +51,7 @@ $app->get('/hello/{name}', function ($request, $response, $args) {
 
 ### Simpler codebase
 
-The framework codebase is much simpler. Previously, the application class contained many methods concerning rendering or response headers. This is no longer the case as they have been migrated into other appropriate classes. For example, the `contentType()` and `status()` methods are removed, and you must use the response object's methods to modify the HTTP response. Slim no longer ships with view or logger objects allowing you to pick the best components for your needs. We do, of course, continue to provide integration with the [Twig](http://twig.sensiolabs.org) templating component via [Twig-View](https://github.com/slimphp/Twig-View) and also have PHP view script integtation via [PHP-View](https://github.com/slimphp/PHP-View).
+The framework codebase is much simpler. Previously, the application class contained many methods concerning rendering or response headers. This is no longer the case as they have been migrated into other appropriate classes. For example, the `contentType()` and `status()` methods are removed, and you must use the response object's methods to modify the HTTP response. Slim no longer ships with view or logger objects allowing you to pick the best components for your needs. We do, of course, continue to provide integration with the [Twig](http://twig.sensiolabs.org) templating component via [Twig-View](https://github.com/slimphp/Twig-View) and also have PHP view script integration via [PHP-View](https://github.com/slimphp/PHP-View).
 
 
 

--- a/_posts/2016-02-25-slim-3.2.0.md
+++ b/_posts/2016-02-25-slim-3.2.0.md
@@ -4,7 +4,7 @@ description: Slim 3.2.0 released!
 layout: post
 ---
 
-We have released Slim version [3.2.0](https://github.com/slimphp/Slim/releases/tag/3.2.0). There are not that many changes since 3.1.0, but we found a few bugs to fix and have added a few nice improvemnts, particuarly around error handling.
+We have released Slim version [3.2.0](https://github.com/slimphp/Slim/releases/tag/3.2.0). There are not that many changes since 3.1.0, but we found a few bugs to fix and have added a few nice improvements, particularly around error handling.
 
 
 The key changes are:

--- a/docs/v3/cookbook/environment.md
+++ b/docs/v3/cookbook/environment.md
@@ -2,7 +2,7 @@
 title: Getting and Mocking the Environment
 ---
 
-The Environment object encapsulates the `$_SERVER` superglobal array and decouples the Slim application from the PHP global environment. Decoupling the Slim application from the PHP global environment lets us create HTTP requests that may (or may not) resemble the global environment. This is particuarly useful for unit testing and initiating sub-requests. You can fetch the current Environment object anywhere in your Slim application like this:
+The Environment object encapsulates the `$_SERVER` superglobal array and decouples the Slim application from the PHP global environment. Decoupling the Slim application from the PHP global environment lets us create HTTP requests that may (or may not) resemble the global environment. This is particularly useful for unit testing and initiating sub-requests. You can fetch the current Environment object anywhere in your Slim application like this:
 
 ```php
 $container = $app->getContainer();

--- a/docs/v3/tutorial/first-app.md
+++ b/docs/v3/tutorial/first-app.md
@@ -408,7 +408,7 @@ To use this in my template, I need to make the router available in the template 
     $response = $this->view->render($response, 'tickets.phtml', ['tickets' => $tickets, 'router' => $this->router]);
 ```
 
-With the `/tickets/{id}` route having a friendly name, and the router now available in our template, this is what makes the `pathFor()` call in our template work.  By supplying the `id`, this gets used as a named placeholder in the URL pattern, and the correct URL for linking to that route with those values is created.  This feature is brilliant for readable template URLs and is even better if you ever need to change a URL format for any reason - no need to grep templates to see where it's used.  This approach is definitely recomended, especially for links you'll use a lot.
+With the `/tickets/{id}` route having a friendly name, and the router now available in our template, this is what makes the `pathFor()` call in our template work.  By supplying the `id`, this gets used as a named placeholder in the URL pattern, and the correct URL for linking to that route with those values is created.  This feature is brilliant for readable template URLs and is even better if you ever need to change a URL format for any reason - no need to grep templates to see where it's used.  This approach is definitely recommended, especially for links you'll use a lot.
 
 ## Where Next?
 


### PR DESCRIPTION
## Problem
There are several minor spelling errors on the v3 docs site.

## Background
While reading the v3 docs I noticed a minor spelling error. As part of fixing it, I ran the v3 docs through a [Markdown Spelling Tool](https://www.npmjs.com/package/markdown-spellcheck). I like the report as `mdspell -n -r  "**/*.md"`. 

## Solution
Fix some very old and minor spelling errors. Github isn't showing the diff highlighting in `docs/v3/tutorial/first-app.md`. The fix there is `recomended`.