### PR TITLE
Add example to override notFoundHandler after App

### DIFF
--- a/docs/v3/handlers/not-found.md
+++ b/docs/v3/handlers/not-found.md
@@ -15,7 +15,7 @@ A Slim Framework application's Not Found handler is a Pimple service. You can su
 ```php
 $c = new \Slim\Container(); //Create Your container
 
-//Override the default Not Found Handler before App
+//Override the default Not Found Handler before creating App
 $c['notFoundHandler'] = function ($c) {
     return function ($request, $response) use ($c) {
         return $c['response']

--- a/docs/v3/handlers/not-found.md
+++ b/docs/v3/handlers/not-found.md
@@ -10,12 +10,12 @@ Each Slim Framework application has a default Not Found handler. This handler se
 
 ## Custom Not Found handler
 
-A Slim Framework application's Not Found handler is a Pimple service. You can substitute your own Not Found handler by defining a custom Pimple factory method with the application container.
+A Slim Framework application's Not Found handler is a Pimple service. You can substitute your own Not Found handler by defining a custom Pimple factory method with the application container *before* you instantiate the App object.
 
 ```php
 $c = new \Slim\Container(); //Create Your container
 
-//Override the default Not Found Handler
+//Override the default Not Found Handler before App
 $c['notFoundHandler'] = function ($c) {
     return function ($request, $response) use ($c) {
         return $c['response']
@@ -37,3 +37,23 @@ In this example, we define a new `notFoundHandler` factory that returns a callab
 2. A `\Psr\Http\Message\ResponseInterface` instance
 
 The callable **MUST** return an appropriate `\Psr\Http\Message\ResponseInterface` instance.
+
+If you wish to override the default Not Found handler *after* you instantiate the App object you can `unset` the default handler then overwrite it.
+
+```php
+$c = new \Slim\Container(); //Create Your container
+
+//Create Slim
+$app = new \Slim\App($c);
+
+//... Your code
+
+//Override the default Not Found Handler after App
+unset($app->getContainer()['notFoundHandler']);
+$app->getContainer()['notFoundHandler'] = function ($c) {
+    return function ($request, $response) use ($c) {
+        $response = new \Slim\Http\Response(404);
+        return $response->write("Page not found");
+    };
+};
+```


### PR DESCRIPTION
Emphasize original example must happen before App is created, add second example to show how to override after App is created. Fixes https://github.com/slimphp/Slim-Website/issues/315