### PR TITLE
Document alternative way to access $app in route groups

### DIFF
--- a/docs/v3/objects/router.md
+++ b/docs/v3/objects/router.md
@@ -294,11 +294,11 @@ To help organize routes into logical groups, the `\Slim\App` also provides a `gr
 
 ```php
 $app = new \Slim\App();
-$app->group('/users/{id:[0-9]+}', function () {
-    $this->map(['GET', 'DELETE', 'PATCH', 'PUT'], '', function ($request, $response, $args) {
+$app->group('/users/{id:[0-9]+}', function (App $app) {
+    $app->map(['GET', 'DELETE', 'PATCH', 'PUT'], '', function ($request, $response, $args) {
         // Find, delete, patch or replace user identified by $args['id']
     })->setName('user');
-    $this->get('/reset-password', function ($request, $response, $args) {
+    $app->get('/reset-password', function ($request, $response, $args) {
         // Route for /users/{id:[0-9]+}/reset-password
         // Reset the password for user identified by $args['id']
     })->setName('user-password-reset');
@@ -308,8 +308,8 @@ $app->group('/users/{id:[0-9]+}', function () {
 The group pattern can be empty, enabling the logical grouping of routes that do not share a common pattern.
 
 ```php
-$app->group('', function() {
-    $this->get('/billing', function ($request, $response, $args) {
+$app->group('', function(App $app) {
+    $app->get('/billing', function ($request, $response, $args) {
         // Route for /billing
     });
     $this->get('/invoice/{id:[0-9]+}', function ($request, $response, $args) {
@@ -318,7 +318,7 @@ $app->group('', function() {
 })->add( new SharedMiddleware() );
 ```
 
-Note inside the group closure, `$this` is used instead of `$app`. Slim binds the closure to the application instance for you, just like it is the case with route callback binds with container instance.
+Note inside the group closure, `$this` can be used instead of `$app`. Slim binds the closure to the application instance for you, just like it is the case with route callback binds with container instance.
 
 * inside group closure, `$this` is bound to the instance of `Slim\App`
 * inside route closure, `$this` is bound to the instance of `Slim\Container`


### PR DESCRIPTION
Adds documentation for this https://github.com/slimphp/Slim/blob/a5a2da92d24c2c30384ff89d90008327f9040cb8/Slim/RouteGroup.php#L45

And since we are talking about it already, why is there the binding feature? It breaks static code analysis and makes things needlessly automagical. I can not think of any advantages using `$this` has over using `$app`. Are there any future plans with it for version 4?