### PR TITLE
Remove leading backslash in code example

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@ description: Slim is a PHP micro framework that helps you quickly write simple y
             yet powerful web applications and APIs.
         </p>
         <pre class="language-php"><code>&lt;?php
-use \Psr\Http\Message\ServerRequestInterface as Request;
-use \Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
 
 require 'vendor/autoload.php';
 


### PR DESCRIPTION
This backslash is not necessary as `use` statements can only contain FQN.