### PR TITLE
Use $realpath_root instead of $document_root

### DIFF
--- a/docs/v3/start/web-servers.md
+++ b/docs/v3/start/web-servers.md
@@ -62,7 +62,7 @@ server {
         try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_param SCRIPT_NAME $fastcgi_script_name;
         fastcgi_index index.php;
         fastcgi_pass 127.0.0.1:9000;


### PR DESCRIPTION
Using `$document_root`, Nginx won't follow symlinks to actual file path. This will be a problem deploying application to the server in which we use symlinks to link application root (`root` in Nginx config) to latest release. It may worth mentioning that doing so will make make deployment smooth and add option to rollback to previous release by a single symlink update.