### PR TITLE
Fix the example code for the group middleware

### DIFF
--- a/docs/v4/concepts/middleware.md
+++ b/docs/v4/concepts/middleware.md
@@ -281,7 +281,7 @@ $app->group('/utils', function (RouteCollectorProxy $group) {
     });
 })->add(function (Request $request, RequestHandler $handler) use ($app) {
     $response = $handler->handle($request);
-    $dateOrTime = (string)$response->getBody();
+    $dateOrTime = (string) $response->getBody();
 
     $response = $app->getResponseFactory()->createResponse();
     $response->getBody()->write('It is now ' . $dateOrTime . '. Enjoy!');

--- a/docs/v4/concepts/middleware.md
+++ b/docs/v4/concepts/middleware.md
@@ -248,7 +248,7 @@ This would output this HTTP response body:
 Hello World
 ```
 
-### Group Middleware
+### Group middleware
 
 In addition to the overall application, and standard routes being able to accept middleware, the **group()** multi-route definition functionality, also allows individual routes internally. Route group middleware is invoked _only if_ its route matches one of the defined HTTP request methods and URIs from the group. To add middleware within the callback, and entire-group middleware to be set by chaining **add()** after the **group()** method.
 
@@ -271,21 +271,25 @@ $app->get('/', function (Request $request, Response $response) {
 
 $app->group('/utils', function (RouteCollectorProxy $group) {
     $group->get('/date', function (Request $request, Response $response) {
-        return $response->getBody()->write(date('Y-m-d H:i:s'));
+        $response->getBody()->write(date('Y-m-d H:i:s'));
+	return $response;
     });
     
     $group->get('/time', function (Request $request, Response $response) {
-        return $response->getBody()->write(time());
+        $response->getBody()->write(time());
+	return $response;
     });
 })->add(function (Request $request, RequestHandler $handler) {
     $response = $handler->handle($request);
     $dateOrTime = (string) $response->getBody();
     
     $response = new Response();
-    $response->write('It is now ' . $dateOrTime . '. Enjoy!');
+    $response->getBody()->write('It is now ' . $dateOrTime . '. Enjoy!');
     
     return $response;
 });
+
+$app->run();
 ```
 
 When calling the **/utils/date** method, this would output a string similar to the below

--- a/docs/v4/concepts/middleware.md
+++ b/docs/v4/concepts/middleware.md
@@ -255,10 +255,10 @@ In addition to the overall application, and standard routes being able to accept
 Sample Application, making use of callback middleware on a group of url-handlers
 ```php
 <?php
+use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
 use Slim\Factory\AppFactory;
-use Slim\Psr7\Response;
 use Slim\Routing\RouteCollectorProxy;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -279,13 +279,13 @@ $app->group('/utils', function (RouteCollectorProxy $group) {
         $response->getBody()->write(time());
         return $response;
     });
-})->add(function (Request $request, RequestHandler $handler) {
+})->add(function (Request $request, RequestHandler $handler) use ($app) {
     $response = $handler->handle($request);
-    $dateOrTime = (string) $response->getBody();
-    
-    $response = new Response();
-    $response->getBody()->write('It is now ' . $dateOrTime . '. Enjoy!');
-    
+    $dateOrTime = (string)$response->getBody();
+
+    $response = $app->getResponseFactory()->createResponse();
+    $response->getBody()->write('It is now '.$dateOrTime.'. Enjoy!');
+
     return $response;
 });
 

--- a/docs/v4/concepts/middleware.md
+++ b/docs/v4/concepts/middleware.md
@@ -272,12 +272,12 @@ $app->get('/', function (Request $request, Response $response) {
 $app->group('/utils', function (RouteCollectorProxy $group) {
     $group->get('/date', function (Request $request, Response $response) {
         $response->getBody()->write(date('Y-m-d H:i:s'));
-	return $response;
+        return $response;
     });
     
     $group->get('/time', function (Request $request, Response $response) {
         $response->getBody()->write(time());
-	return $response;
+        return $response;
     });
 })->add(function (Request $request, RequestHandler $handler) {
     $response = $handler->handle($request);

--- a/docs/v4/concepts/middleware.md
+++ b/docs/v4/concepts/middleware.md
@@ -284,7 +284,7 @@ $app->group('/utils', function (RouteCollectorProxy $group) {
     $dateOrTime = (string)$response->getBody();
 
     $response = $app->getResponseFactory()->createResponse();
-    $response->getBody()->write('It is now '.$dateOrTime.'. Enjoy!');
+    $response->getBody()->write('It is now ' . $dateOrTime . '. Enjoy!');
 
     return $response;
 });


### PR DESCRIPTION
We should not return the result of `$response->getBody()->write(...)` as this is an integer. The route callback has to return a `ResponseInterface`.

And `$response` does not have a `write` method - instead use `getBody()->write()`.