### PR TITLE
Cast int to string

### DIFF
--- a/docs/v4/concepts/middleware.md
+++ b/docs/v4/concepts/middleware.md
@@ -278,7 +278,7 @@ $app->group('/utils', function (RouteCollectorProxy $group) {
     });
     
     $group->get('/time', function (Request $request, Response $response) {
-        $response->getBody()->write(time());
+        $response->getBody()->write((string)time());
         return $response;
     });
 })->add(function (Request $request, RequestHandler $handler) use ($app) {


### PR DESCRIPTION
The PSR-7 Stream `write` method expects to have a `string` as first parameter.