### PR TITLE
Update Slack joining link

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@ $app-&gt;run();</code></pre>
         <p>
             We can be found on <a href="https://slack.com">Slack</a> at <a href="https://slimphp.slack.com">slimphp.slack.com</a>.
             <p class="center">
-                <a class="btn btn-primary btn-lg" href="https://slimphp-slack-invite.herokuapp.com/">Get Access to the Slack Channel</a>
+                <a class="btn btn-primary btn-lg" href="https://join.slack.com/t/slimphp/shared_invite/enQtNjMxMjExMzYxMTU0LWVmNWQ1MWMxODA0ZjI2YTdkYzIyYjcxYTA3ZGQ2ZDNhZjdmMGVlODhlYWQ1ZmNhNTdiOWNlNmEzNGRiMjA1Yzc">Get Access to the Slack Channel</a>
             </p>
         </p>
         </p>


### PR DESCRIPTION
Slack now has native support for joining a Slack team, so use it rather than our own solution.