### PR TITLE
Add a nav toggle to the docs TOC for small layouts

### DIFF
--- a/_layouts/docs-v2.html
+++ b/_layouts/docs-v2.html
@@ -3,24 +3,32 @@
     <div class="container-fluid">
         <div class="row">
             <div class="col-md-3">
-                {% include version-selector.html %}
-                {% include search-box.html %}
-                {% for section in page.docs-v2 %}
-                    {% assign isCurrentSection = false %}
-                    {% for item in section.items %}
-                        {% capture itemUrl %}{{ item[0] | replace: '.md', '.html' }}{% unless item[0] contains ".md" %}/{% endunless %}{% endcapture %}
-                        {% if itemUrl == page.url %}
-                            {% assign isCurrentSection = true %}
-                        {% endif %}
-                    {% endfor %}
-                    <h3 class="toc-title{% if isCurrentSection %} active{% endif %}">{{ section.title }}</h3>
-                    <ul class="toc-links">
+                <div class="toc-nav-toggle">
+                    <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#tocNav"
+                            aria-expanded="false" aria-controls="tocNav">
+                        Toggle Navigation
+                    </button>
+                </div>
+                <div class="collapse toc-nav-collapse" id="tocNav">
+                    {% include version-selector.html %}
+                    {% include search-box.html %}
+                    {% for section in page.docs-v2 %}
+                        {% assign isCurrentSection = false %}
                         {% for item in section.items %}
                             {% capture itemUrl %}{{ item[0] | replace: '.md', '.html' }}{% unless item[0] contains ".md" %}/{% endunless %}{% endcapture %}
-                            <li><a href="{{ itemUrl }}">{{ item[1] }}</a></li>
+                            {% if itemUrl == page.url %}
+                                {% assign isCurrentSection = true %}
+                            {% endif %}
                         {% endfor %}
-                    </ul>
-                {% endfor %}
+                        <h3 class="toc-title{% if isCurrentSection %} active{% endif %}">{{ section.title }}</h3>
+                        <ul class="toc-links">
+                            {% for item in section.items %}
+                                {% capture itemUrl %}{{ item[0] | replace: '.md', '.html' }}{% unless item[0] contains ".md" %}/{% endunless %}{% endcapture %}
+                                <li><a href="{{ itemUrl }}">{{ item[1] }}</a></li>
+                            {% endfor %}
+                        </ul>
+                    {% endfor %}
+                </div>
             </div>
             <div class="col-md-8 docs-content">
                 <h1 class="page-header">{{ page.title }}</h1>

--- a/_layouts/docs-v3.html
+++ b/_layouts/docs-v3.html
@@ -3,24 +3,32 @@
     <div class="container-fluid">
         <div class="row">
             <div class="col-md-3">
-                {% include version-selector.html %}
-                {% include search-box.html %}
-                {% for section in page.docs-v3 %}
-                    {% assign isCurrentSection = false %}
-                    {% for item in section.items %}
-                        {% capture itemUrl %}{{ item[0] | replace: '.md', '.html' }}{% unless item[0] contains ".md" %}/{% endunless %}{% endcapture %}
-                        {% if itemUrl == page.url %}
-                            {% assign isCurrentSection = true %}
-                        {% endif %}
-                    {% endfor %}
-                    <h3 class="toc-title{% if isCurrentSection %} active{% endif %}">{{ section.title }}</h3>
-                    <ul class="toc-links">
+                <div class="toc-nav-toggle">
+                    <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#tocNav"
+                            aria-expanded="false" aria-controls="tocNav">
+                        Toggle Navigation
+                    </button>
+                </div>
+                <div class="collapse toc-nav-collapse" id="tocNav">
+                    {% include version-selector.html %}
+                    {% include search-box.html %}
+                    {% for section in page.docs-v3 %}
+                        {% assign isCurrentSection = false %}
                         {% for item in section.items %}
                             {% capture itemUrl %}{{ item[0] | replace: '.md', '.html' }}{% unless item[0] contains ".md" %}/{% endunless %}{% endcapture %}
-                            <li><a href="{{ itemUrl }}">{{ item[1] }}</a></li>
+                            {% if itemUrl == page.url %}
+                                {% assign isCurrentSection = true %}
+                            {% endif %}
                         {% endfor %}
-                    </ul>
-                {% endfor %}
+                        <h3 class="toc-title{% if isCurrentSection %} active{% endif %}">{{ section.title }}</h3>
+                        <ul class="toc-links">
+                            {% for item in section.items %}
+                                {% capture itemUrl %}{{ item[0] | replace: '.md', '.html' }}{% unless item[0] contains ".md" %}/{% endunless %}{% endcapture %}
+                                <li><a href="{{ itemUrl }}">{{ item[1] }}</a></li>
+                            {% endfor %}
+                        </ul>
+                    {% endfor %}
+                </div>
             </div>
 
             <div class="col-md-8 docs-content">

--- a/_layouts/docs-v4.html
+++ b/_layouts/docs-v4.html
@@ -3,30 +3,37 @@
     <div class="container-fluid">
         <div class="row">
             <div class="col-md-3">
-                {% include version-selector.html %}
-                {% include search-box.html %}
-                {% for section in page.docs-v4 %}
-                    {% assign isCurrentSection = false %}
-                    {% for item in section.items %}
-                        {% capture itemUrl %}{{ item[0] | replace: '.md', '.html' }}{% unless item[0] contains ".md" %}/{% endunless %}{% endcapture %}
-                        {% if itemUrl == page.url %}
-                            {% assign isCurrentSection = true %}
-                        {% endif %}
-                    {% endfor %}
-                    <h3 class="toc-title{% if isCurrentSection %} active{% endif %}">{{ section.title }}</h3>
-                    <ul class="toc-links">
+                <div class="toc-nav-toggle">
+                    <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#tocNav"
+                            aria-expanded="false" aria-controls="tocNav">
+                        Toggle Navigation
+                    </button>
+                </div>
+                <div class="collapse toc-nav-collapse" id="tocNav">
+                    {% include version-selector.html %}
+                    {% include search-box.html %}
+                    {% for section in page.docs-v4 %}
+                        {% assign isCurrentSection = false %}
                         {% for item in section.items %}
                             {% capture itemUrl %}{{ item[0] | replace: '.md', '.html' }}{% unless item[0] contains ".md" %}/{% endunless %}{% endcapture %}
-                            <li><a href="{{ itemUrl }}">{{ item[1] }}</a></li>
+                            {% if itemUrl == page.url %}
+                                {% assign isCurrentSection = true %}
+                            {% endif %}
                         {% endfor %}
+                        <h3 class="toc-title{% if isCurrentSection %} active{% endif %}">{{ section.title }}</h3>
+                        <ul class="toc-links">
+                            {% for item in section.items %}
+                                {% capture itemUrl %}{{ item[0] | replace: '.md', '.html' }}{% unless item[0] contains ".md" %}/{% endunless %}{% endcapture %}
+                                <li><a href="{{ itemUrl }}">{{ item[1] }}</a></li>
+                            {% endfor %}
+                        </ul>
+                    {% endfor %}
+
+                    <h3 class="toc-title">Professional Support</h3>
+                    <ul class="toc-links">
+                        <li><a href="https://tidelift.com/subscription/pkg/packagist-slim-slim?utm_source=packagist-slim-slim&utm_medium=referral&utm_campaign=website">Professional support from Tidelift</a></li>
                     </ul>
-                {% endfor %}
-
-                <h3 class="toc-title">Professional Support</h3>
-                <ul class="toc-links">
-                    <li><a href="https://tidelift.com/subscription/pkg/packagist-slim-slim?utm_source=packagist-slim-slim&utm_medium=referral&utm_campaign=website">Professional support from Tidelift</a></li>
-                </ul>
-
+                </div>
             </div>
 
             <div class="col-md-8 docs-content">

--- a/assets/less/layout.less
+++ b/assets/less/layout.less
@@ -42,6 +42,40 @@ pre {
     }
 }
 
+.toc-nav-toggle {
+  margin-bottom: 2em;
+
+  @media (min-width: @screen-md-min) {
+    display: none !important;
+  }
+}
+
+.toc-nav-collapse {
+  overflow-x: visible;
+  &:extend(.clearfix all);
+  -webkit-overflow-scrolling: touch;
+
+  &.in {
+    overflow-y: auto;
+  }
+
+  @media (min-width: @screen-md-min) {
+    width: auto;
+
+    &.collapse {
+      display: block !important;
+      visibility: visible !important;
+      height: auto !important;
+      padding-bottom: 0;
+      overflow: visible !important;
+    }
+
+    &.in {
+      overflow-y: visible;
+    }
+  }
+}
+
 .toc-title{
   &.active {
     border-left: 1px solid @green;
@@ -70,8 +104,10 @@ pre {
 }
 
 .docs-content {
+  margin-top: 2em;
   word-wrap: break-word;
 }
+
 
 @import "../bootstrap/less/variables";
 
@@ -89,6 +125,7 @@ pre {
 
 @media (min-width: @screen-md-min) {
   .docs-content {
+    margin-top: 0;
     padding-left: 2em;
   }
 }


### PR DESCRIPTION
This PR would add a navigation toggle to the three docs layout files in order to be able to collapse the table-of-contents on small layouts.

![Animation](https://user-images.githubusercontent.com/3974990/58460925-dbf11780-812e-11e9-9c47-78a3a6b1431f.gif)

The version selector and the search box would also be collapsed.

I added a vertical margin of `2em` between the TOC and the `docs-content` in case they are stacked vertically. Otherwise this margin gets removed.

I added a vertical margin of `2em` between the TOC toggle button and the actual TOC content.

Note: I have not commited the generated css file. Should I?
