### PR TITLE
Update 2019-04-25-slim-4.0.0-alpha-release.md

### DIFF
--- a/_posts/2019-04-25-slim-4.0.0-alpha-release.md
+++ b/_posts/2019-04-25-slim-4.0.0-alpha-release.md
@@ -148,7 +148,7 @@ use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Factory\AppFactory;
 
-require __DIR__ . '/../vendor/autoload.php.';
+require __DIR__ . '/../vendor/autoload.php';
 
 $app = AppFactory::create();
 


### PR DESCRIPTION
Removed trailing '.' after the .php