### PR TITLE
fix invalid namespace

### DIFF
--- a/docs/v3/tutorial/first-app.md
+++ b/docs/v3/tutorial/first-app.md
@@ -174,7 +174,7 @@ My setup is pretty simple since I only have a few extra classes, they're just in
     },
     "autoload": {
         "psr-4": {
-            "": "classes/"
+            "\\": "classes/"
         }
     }
 }


### PR DESCRIPTION
The empty namespace works for demonstration purposes, but Composer complains about it when running Satis. Looks like an empty namespace is valid as long as it still ends in \\\

In PackageRepository.php line 55:

A repository of type "package" contains an invalid package definition: Invalid package information:
autoload.psr-4 : invalid value (_empty_), namespaces must end with a namespace separator, should be \_empty\_\\\