### PR TITLE
[4.x] Add static closure hint

### DIFF
--- a/docs/v4/objects/routing.md
+++ b/docs/v4/objects/routing.md
@@ -154,6 +154,31 @@ $app->get('/hello/{name}', function ($request, $response, $args) {
 });
 ```
 
+<div class="alert alert-info">
+    <div><strong>Heads Up!</strong></div>
+    <p>Slim does not support <em>static closures</em>.</p>
+</div>
+
+However it is possible to create controller classes with static actions (methods).
+```php
+class Controller
+{
+    public static function home(
+        ServerRequest $request,
+        Response $response,
+        array $args
+    ): ResponseInterface {
+        $response->write('Static route handler');
+
+        return $response;
+    }
+}
+
+// ...
+ 
+$app->get('/', Controller::class . ':home');
+```
+
 ## Redirect helper
 
 You can add a route that redirects `GET` HTTP requests to a different URL with

--- a/docs/v4/objects/routing.md
+++ b/docs/v4/objects/routing.md
@@ -156,7 +156,7 @@ $app->get('/hello/{name}', function ($request, $response, $args) {
 
 <div class="alert alert-info">
     <div><strong>Heads Up!</strong></div>
-    <p>Slim does not support <em>static closures</em>.</p>
+    <p>Slim does not support <code>static</code> closures.</p>
 </div>
 
 However it is possible to create controller classes with static actions (methods).

--- a/docs/v4/objects/routing.md
+++ b/docs/v4/objects/routing.md
@@ -159,26 +159,6 @@ $app->get('/hello/{name}', function ($request, $response, $args) {
     <p>Slim does not support <code>static</code> closures.</p>
 </div>
 
-However it is possible to create controller classes with static actions (methods).
-```php
-class Controller
-{
-    public static function home(
-        ServerRequest $request,
-        Response $response,
-        array $args
-    ): ResponseInterface {
-        $response->write('Static route handler');
-
-        return $response;
-    }
-}
-
-// ...
- 
-$app->get('/', Controller::class . ':home');
-```
-
 ## Redirect helper
 
 You can add a route that redirects `GET` HTTP requests to a different URL with


### PR DESCRIPTION
This PR would add a small section about static closures and a small hint on the use of static class methods.

I was not sure about the position of the hint. Later on that page, there is a section *Allow Slim to instantiate the controller* - probably this is better for the hint about static class methods.

It addresses https://github.com/slimphp/Slim/issues/2740