### PR TITLE
Link to latest Eloquent documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -105,5 +105,5 @@ routing, and error handling.
 [csrf]: https://github.com/slimphp/Slim-Csrf/
 [httpcache]: https://github.com/slimphp/Slim-HttpCache
 [flash]: https://github.com/slimphp/Slim-Flash
-[eloquent]: https://laravel.com/docs/5.1/eloquent
+[eloquent]: https://laravel.com/docs/eloquent
 [doctrine]: http://www.doctrine-project.org/projects/orm.html

--- a/docs/v3/cookbook/database-eloquent.md
+++ b/docs/v3/cookbook/database-eloquent.md
@@ -2,7 +2,7 @@
 title: Using Eloquent with Slim
 ---
 
-You can use a database ORM such as [Eloquent](https://laravel.com/docs/5.1/eloquent) to connect your SlimPHP application to a database.
+You can use a database ORM such as [Eloquent](https://laravel.com/docs/eloquent) to connect your SlimPHP application to a database.
 
 ## Adding Eloquent to your application
 
@@ -142,4 +142,4 @@ $record = $this->table->find(1);
 
 ## More information
 
-[Eloquent](https://laravel.com/docs/5.1/eloquent) Documentation
+[Eloquent](https://laravel.com/docs/eloquent) Documentation


### PR DESCRIPTION
Always links to the latest stable Eloquent documentation: https://laravel.com/docs/eloquent