### PR TITLE
Update web-servers.md to include "static files"

### DIFF
--- a/docs/v3/start/web-servers.md
+++ b/docs/v3/start/web-servers.md
@@ -5,7 +5,7 @@ title: Web Servers
 It is typical to use the front-controller pattern to funnel appropriate HTTP
 requests received by your web server to a single PHP file. The instructions
 below explain how to tell your web server to send HTTP requests to your PHP
-front-controller file.
+front-controller file if no matching static files or directories exist.
 
 ## PHP built-in server
 


### PR DESCRIPTION
Added mention of static files and directories for more clarity and better visibility when searching (currently when searching the docs for "static files" you get the old v2 web servers configuration page with no clear path to this page).