### PR TITLE
Change PSR-7 implementations CI status table to list

### DIFF
--- a/_posts/2019-08-01-slim-4.0.0-release.md
+++ b/_posts/2019-08-01-slim-4.0.0-release.md
@@ -10,12 +10,11 @@ We are excited to announce the Slim 4.0.0 release. Please direct all your feedba
 [![Coverage Status](https://coveralls.io/repos/github/slimphp/Slim/badge.svg?branch=4.x)](https://coveralls.io/github/slimphp/Slim?branch=4.x)
 
 # Supported PSR-7 Implementations CI Status
-| #   | PSR-7 Implementation | Status         |
-| --- | -------------------- | -------------- |
-| 1   | Slim PSR-7           | [![Slim](https://travis-matrix-badges.herokuapp.com/repos/adriansuter/Slim4-CI/branches/master/1)](https://travis-ci.org/adriansuter/Slim4-CI)              |
-| 2   | Nyholm               | [![Nyholm](https://travis-matrix-badges.herokuapp.com/repos/adriansuter/Slim4-CI/branches/master/2)](https://travis-ci.org/adriansuter/Slim4-CI)            |
-| 3   | Guzzle               | [![Guzzle](https://travis-matrix-badges.herokuapp.com/repos/adriansuter/Slim4-CI/branches/master/3)](https://travis-ci.org/php-http/psr7-integration-tests) |
-| 4   | Zend                 | [![Zend](https://travis-matrix-badges.herokuapp.com/repos/adriansuter/Slim4-CI/branches/master/4)](https://travis-ci.org/php-http/psr7-integration-tests)   |
+
+* [![Slim](https://travis-matrix-badges.herokuapp.com/repos/adriansuter/Slim4-CI/branches/master/1)](https://travis-ci.org/adriansuter/Slim4-CI) Slim PSR-7
+* [![Nyholm](https://travis-matrix-badges.herokuapp.com/repos/adriansuter/Slim4-CI/branches/master/2)](https://travis-ci.org/adriansuter/Slim4-CI) Nyholm
+* [![Guzzle](https://travis-matrix-badges.herokuapp.com/repos/adriansuter/Slim4-CI/branches/master/3)](https://travis-ci.org/php-http/psr7-integration-tests) Guzzle
+* [![Zend](https://travis-matrix-badges.herokuapp.com/repos/adriansuter/Slim4-CI/branches/master/4)](https://travis-ci.org/php-http/psr7-integration-tests) Zend
 
 *Note: Travis-CI is configured to be triggered automatically at least every 24 hours.*
 


### PR DESCRIPTION
As the table in section "Supported PSR-7 Implementations CI Status" of the blog post did not work as expected, and if it works it does not have any stylings associated, this PR would simply convert the table into a simple list.