### PR TITLE
Add routing middleware to the hello-world example

### DIFF
--- a/docs/v4/start/installation.md
+++ b/docs/v4/start/installation.md
@@ -58,6 +58,8 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $app = AppFactory::create();
 
+$app->addRoutingMiddleware();
+
 $app->get('/', function (Request $request, Response $response, $args) {
     $response->getBody()->write("Hello world!");
     return $response;


### PR DESCRIPTION
In the last time new users had some routing (404 error) issues, because of the missing routing middleware. I guess people just copy-pasting the code from the hello-world example an run into trouble as soon they add more routes or use other http ports.

To make the onboading easier, we should also add the Routingmiddleware to the hello world example:

```php
$app->addRoutingMiddleware();
```