### PR TITLE
Make it possible to have both, ORM and migrations

### DIFF
--- a/docs/v3/cookbook/database-doctrine.md
+++ b/docs/v3/cookbook/database-doctrine.md
@@ -121,6 +121,7 @@ already present at `vendor/bin`. But in order to work, this script needs a [`cli
 file at the root of the project telling it how to find the `EntityManager` we just set up:
 
 <figure markdown="1">
+
 ```php
 <?php
 
@@ -133,10 +134,9 @@ use Slim\Container;
 /** @var Container $container */
 $container = require_once __DIR__ . '/bootstrap.php';
 
-ConsoleRunner::run(
-    ConsoleRunner::createHelperSet($container[EntityManager::class])
-);
+return ConsoleRunner::createHelperSet($container[EntityManager::class])
 ```
+
 <figcaption>Figure 4: Enabling Doctrine's console app.</figcaption>
 </figure>
 


### PR DESCRIPTION
1. Creating console application is redundant because Doctrine ORM will do this for us automatically (https://github.com/doctrine/orm/blob/master/bin/doctrine.php#L54). We only have to provide helper set.

2. If we create console application inside `cli-config.php` we make it impossible to use doctrine migrations because migration plugin uses the same `cli-config.php` to get helper set from, but creates console application in different way.
(
https://github.com/doctrine/migrations/blob/master/bin/doctrine-migrations.php#L91
https://www.doctrine-project.org/projects/doctrine-migrations/en/latest/reference/configuration.html#configuration
)