### PR TITLE
Fix redirect loop that causes in 404 path

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,23 +8,3 @@ permalink: /404.html
 # 404
 
 Page not found! :(
-
-<script>
-  var pathname = window.location.pathname;
-
-  function pathContains(str) {
-    return pathname.indexOf(str) !== -1;
-  }
-
-  if (pathContains('/docs/')) {
-    var content = pathname.substr(8);
-
-    if (pathContains('/v4/')) {
-      window.location = '/docs/v4' + content;
-    } else if (pathContains('/v3/')) {
-      window.location = '/docs/v3' + content;
-    } else if (pathContains('/v2/')) {
-      window.location = '/docs/v2' + content;
-    }
-  }
-</script>


### PR DESCRIPTION
The following URL causes a redirect loop:
- http://www.slimframework.com/docs/v2/aaa
- http://www.slimframework.com/docs/v3/xyz
- http://www.slimframework.com/docs/v4/aaa/bbb

I saw the history of `404.html`.
- https://github.com/slimphp/Slim-Website/commit/336bbdfbcf52dc9dedc4a45ad42b426ba6e31151#diff-aa8eb2fe477b2d36ecc0f14d6422513fR13
- https://github.com/slimphp/Slim-Website/commit/8e9441a7ca026626973f495c324ea357340977ad#diff-aa8eb2fe477b2d36ecc0f14d6422513fR14

At first, if it was `404` when accessing `/docs/xxx`, it seems that it was intended to redirect `/docs/v3/xxx`.

Looking at `_config.yml`, there seems to be no path other than `/docs/v2/`, `/docs/v3/`, and `/docs/v4/`, so I think this process is unnecessary.
I think that displaying 404 page is enough, so what do you think about it?

Best regards,