### PR TITLE
Fix output buffer cleanup example

### DIFF
--- a/docs/v4/objects/application.md
+++ b/docs/v4/objects/application.md
@@ -220,7 +220,7 @@ class ShutdownHandler
             $exception = new HttpInternalServerErrorException($this->request, $message);
             $response = $this->errorHandler->__invoke($this->request, $exception, $this->displayErrorDetails, false, false);
             
-            if (ob_get_contents()) {
+            if (ob_get_length()) {
               ob_clean();
             }
 


### PR DESCRIPTION
Using `ob_get_contents()` returns the whole buffer, consumes more ram and is slower. If the output buffer contains the value `"0"` then the cleanup will not work. Checking the length of the buffer is faster and works with `"0"`.