### PR TITLE
Fix PHP built-in server command

### DIFF
--- a/docs/v4/start/web-servers.md
+++ b/docs/v4/start/web-servers.md
@@ -13,10 +13,14 @@ Run the following command in terminal to start localhost web server,
 assuming `./public/` is public-accessible directory with `index.php` file:
 
 ```bash
-php -S localhost:8888 -t public public/index.php
+cd public/
+php -S localhost:8888
 ```
 
 If you are not using `index.php` as your entry point then change appropriately.
+
+> **Warning:** The built-in web server was designed to aid application development. 
+It may also be useful for testing purposes or for application demonstrations that are run in controlled environments. It is not intended to be a full-featured web server. It should not be used on a public network.
 
 ## Apache configuration
 


### PR DESCRIPTION
The command `php -S localhost:8888 -t public public/index.php` generates the following error, as long as you have only a single `/` route (like in the [installation guide](http://www.slimframework.com/docs/v4/start/installation.html)):

```
PHP Fatal error:  Uncaught Slim\Exception\HttpNotFoundException: Not found. in vendor/slim/slim/Slim\Middleware\RoutingMiddleware.php:91
Stack trace:
#0 vendor/slim/slim/Slim/Routing/RouteRunner.php(71): Slim\Middleware\RoutingMiddleware->performRouting(Object(Slim\Psr7\Request))
#1 vendor/slim/slim/Slim/MiddlewareDispatcher.php(73): Slim\Routing\RouteRunner->handle(Object(Slim\Psr7\Request))
```

If you add second route (e.g. `/test`) the error for the `/` route is gone.

More details: https://discourse.slimframework.com/t/seterrorhandler-custom-handlers/3690

This PR changes the build-in webserver command to make it work in both situations.