### PR TITLE
Fix globbing issue in some shells (zsh)

### DIFF
--- a/docs/v4/start/installation.md
+++ b/docs/v4/start/installation.md
@@ -19,7 +19,7 @@ shown below. This command downloads the Slim Framework and its third-party
 dependencies into your project's `vendor/` directory.
 
 ```bash
-composer require slim/slim:4.*
+composer require "slim/slim:4.*"
 ```
 
 ## Step 3: Install a PSR-7 Implementation and ServerRequest Creator

--- a/docs/v4/start/installation.md
+++ b/docs/v4/start/installation.md
@@ -19,7 +19,7 @@ shown below. This command downloads the Slim Framework and its third-party
 dependencies into your project's `vendor/` directory.
 
 ```bash
-composer require "slim/slim:4.*"
+composer require slim/slim:"4.*"
 ```
 
 ## Step 3: Install a PSR-7 Implementation and ServerRequest Creator


### PR DESCRIPTION
Fix globbing in shell

```
$ composer require slim/slim:4.*
zsh: no matches found: slim/slim:4.*
```