### PR TITLE
Fixed wrong doctrine version and missing semicolon

### DIFF
--- a/docs/v3/cookbook/database-doctrine.md
+++ b/docs/v3/cookbook/database-doctrine.md
@@ -10,7 +10,7 @@ The first step is importing the library into the `vendor` directory of your proj
 
 <figure markdown="1">
 ```bash
-composer require doctrine/orm:^2
+composer require doctrine/orm
 ```
 <figcaption>Figure 1: Require doctrine in your application.</figcaption>
 </figure>
@@ -134,7 +134,7 @@ use Slim\Container;
 /** @var Container $container */
 $container = require_once __DIR__ . '/bootstrap.php';
 
-return ConsoleRunner::createHelperSet($container[EntityManager::class])
+return ConsoleRunner::createHelperSet($container[EntityManager::class]);
 ```
 
 <figcaption>Figure 4: Enabling Doctrine's console app.</figcaption>


### PR DESCRIPTION
Doctrine installation will run error:

"[InvalidArgumentException]
  Could not find package doctrine/orm in a version matching 2"

And missing semi colon in the cli-config.php script.