### PR TITLE
Enhance trailing slash middleware example.

### DIFF
--- a/docs/v3/cookbook/route-patterns.md
+++ b/docs/v3/cookbook/route-patterns.md
@@ -16,9 +16,14 @@ $app->add(function (Request $request, Response $response, callable $next) {
     $uri = $request->getUri();
     $path = $uri->getPath();
     if ($path != '/' && substr($path, -1) == '/') {
+        // recursively remove slashes when its more than 1 slash
+        while(substr($path, -1) == '/') {
+            $path = substr($path, 0, -1);
+        }
+
         // permanently redirect paths with a trailing slash
         // to their non-trailing counterpart
-        $uri = $uri->withPath(substr($path, 0, -1));
+        $uri = $uri->withPath($path);
         
         if($request->getMethod() == 'GET') {
             return $response->withRedirect((string)$uri, 301);


### PR DESCRIPTION
This patch is the fix for issue [#481](https://github.com/slimphp/Slim-Website/issues/481). For slim v3 docs.

This patch appears to make the request faster for multiple trailing slashes as the middleware isn't recursively called after each redirect that happens when a slash is stripped. The `while` loop takes care of it in one request, and it does it relatively fast.