### PR TITLE
Array declaration typo fix

### DIFF
--- a/docs/v2/routing/params.md
+++ b/docs/v2/routing/params.md
@@ -28,7 +28,7 @@ the same as normal route parameters shown above. Here’s an example:
     });
 
 When you invoke this example application with a resource URI “/hello/Josh/T/Lockhart”, the route callback’s `$name`
-argument will be equal to `array('Josh', 'T', Lockhart')`.
+argument will be equal to `array('Josh', 'T', 'Lockhart')`.
 
 ### Optional route parameters
 


### PR DESCRIPTION
Missing `'` in array declaration