### PR TITLE
Update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,7 +70,7 @@ defaults:
           - [/docs/v4/objects/routing.md#route-names, Names]
           - [/docs/v4/objects/routing.md#route-groups, Groups]
           - [/docs/v4/objects/routing.md#route-middleware, Middleware]
-          - [/docs/v4/objects/routing.md#router-caching, Caching]
+          - [/docs/v4/objects/routing.md#route-expressions-caching, Caching]
           - [/docs/v4/objects/routing.md#container-resolution, Container Resolution]
         - title: Packaged Middleware
           items:


### PR DESCRIPTION
The link in the docs to route caching is pointed to `router-caching`. However, it should be pointed to `route-expressions-caching`. I went ahead and made that change.