### PR TITLE
Update life-cycle.md

### DIFF
--- a/docs/v4/concepts/life-cycle.md
+++ b/docs/v4/concepts/life-cycle.md
@@ -6,7 +6,7 @@ title: Lifecycle
 
 ### 1. Instantiation
 
-First, you instantiate the `Slim\App` class. This is the Slim application object. During instantiation, Slim registers default services for each application dependency. The application constructor accepts an optional settings array that configures the application's behavior.
+First, you instantiate the `Slim\App` class. This is the Slim application object. During instantiation, Slim registers default services for each application dependency.
 
 ### 2. Route Definitions
 


### PR DESCRIPTION
In Slim 4 application constructor does not accept optional settings array which will configure application behavior. Settings array was accepted in the constructor of Slim 3 application. So this sentence is incorrect and must be removed from the docs of Slim 4.