### PR TITLE
Update composer slim 4 versions

### DIFF
--- a/_posts/2019-04-25-slim-4.0.0-alpha-release.md
+++ b/_posts/2019-04-25-slim-4.0.0-alpha-release.md
@@ -113,7 +113,7 @@ shown below. This command downloads the Slim Framework and its third-party
 dependencies into your project's `vendor/` directory.
 
 ```bash
-composer require slim/slim:4.0.0-alpha
+composer require slim/slim "^4.0"
 ```
 
 ## Step 3: Install a PSR-7 Implementation and ServerRequest Creator

--- a/_posts/2019-08-01-slim-4.0.0-release.md
+++ b/_posts/2019-08-01-slim-4.0.0-release.md
@@ -138,7 +138,7 @@ shown below. This command downloads the Slim Framework and its third-party
 dependencies into your project's `vendor/` directory.
 
 ```bash
-composer require slim/slim:4.0.0
+composer require slim/slim "^4.0"
 ```
 
 ## Step 3: Install a PSR-7 Implementation and ServerRequest Creator


### PR DESCRIPTION
Some people take the old release pages and try to install the Slim 4 alpha versions, like here

http://www.slimframework.com/2019/04/25/slim-4.0.0-alpha-release.html#step-2-install-slim

This tiny update should fix it.

Source: https://discourse.slimframework.com/t/slim4-why-doesnt-it-work/3209