### PR TITLE
Fix wrong alias of ServerRequestInterface

### DIFF
--- a/docs/v4/objects/response.md
+++ b/docs/v4/objects/response.md
@@ -25,7 +25,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $app = AppFactory::create();
 
-$app->get('/hello', function (ServerRequest $request, Response $response) {
+$app->get('/hello', function (Request $request, Response $response) {
     $response->getBody()->write('Hello World');
     return $response;
 });


### PR DESCRIPTION
I found that `ServerRequestInterface` has the wrong alias, it should be `Request` instead of `ServerRequest`.
Thanks!

```php
use Psr\Http\Message\ServerRequestInterface as Request;
```

```php
$app->get('/hello', function (ServerRequest $request, Response $response)
```

```php
$app->get('/hello', function (Request $request, Response $response)
```