### PR TITLE
Clean up the Nginx example

### DIFF
--- a/docs/v4/start/web-servers.md
+++ b/docs/v4/start/web-servers.md
@@ -64,11 +64,7 @@ server {
 
     location ~ \.php {
         try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
-        fastcgi_index index.php;
+        include fastcgi.conf;
         fastcgi_pass 127.0.0.1:9123;
     }
 }


### PR DESCRIPTION
I noticed that some of the directives in the Nginx example configuration are redundant.

```
include fastcgi_params;	
fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
```

Just include `fastcgi.conf`. The difference between `fastcgi_params` and `fastcgi.conf` is that the latter includes that `SCRIPT_FILENAME` directive.

```
fastcgi_param SCRIPT_NAME $fastcgi_script_name;
```

That is already included in both `fastcgi_params` and `fastcgi.conf`.

```
fastcgi_index index.php;
```

This is [almost never used](https://stackoverflow.com/questions/30802025/what-is-fastcgi-index-in-nginx-used-for).

```
fastcgi_split_path_info ^(.+\.php)(/.+)$;
```

To be honest I don't really understand the intention of this. It appears to set `$fastcgi_script_name` to the same value as it has by default and `$fastcgi_path_info` to some value that is never used and not even passed to fastcgi (there is no `fastcgi_param` that uses `$fastcgi_path_info` either in this config or the default `fastcgi_params`). Well, it might be used if you'd include `snippets/fastcgi-php.conf` on the deb package, but that also does the `fastcgi_split_path_info` itself.