### PR TITLE
Fix h2 and h3 header styling issues 

### DIFF
--- a/assets/less/components/anchors.less
+++ b/assets/less/components/anchors.less
@@ -1,6 +1,6 @@
 .docs-content {
     h2, h3 {
-        display: inline-block;
+        display: table;
         border-bottom: dotted 1px transparent;
 
         &:hover {


### PR DESCRIPTION
This is a (quick) fix to solve the h2,h3 header issue. See #521

Examples

* https://www.slimframework.com/docs/v4/concepts/life-cycle.html

`display: table` is only as wide as its contents require and forces a line break. Other display types didn't work.

## Before

![image](https://user-images.githubusercontent.com/781074/104854064-368f4680-5905-11eb-89fb-c0d6909cda61.png)

## After

![image](https://user-images.githubusercontent.com/781074/104854041-1f505900-5905-11eb-9d79-880fa65dce52.png)
