### PR TITLE
Update Slack invite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@ $app-&gt;run();</code></pre>
         <p>
             We can be found on <a href="https://slack.com">Slack</a> at <a href="https://slimphp.slack.com">slimphp.slack.com</a>.
             <p class="center">
-                <a class="btn btn-primary btn-lg" href="https://slimphp.slack.com">Get Access to the Slack Channel</a>
+                <a class="btn btn-primary btn-lg" href="https://join.slack.com/t/slimphp/shared_invite/zt-81z2y3cy-vHjPqNH_7x_5d5PubtW~Og">Get Access to the Slack Channel</a>
             </p>
         </p>
         </p>


### PR DESCRIPTION
The Slack login page doesn't seem to have an invite link on it anymore. Hence, we need the "Get Access" button to have the invite link in it.