### PR TITLE
Remove getBasePath() & getBaseUrl

### DIFF
--- a/docs/v4/objects/request.md
+++ b/docs/v4/objects/request.md
@@ -150,10 +150,8 @@ methods to inspect the HTTP request's URL parts:
 * getHost()
 * getPort()
 * getPath()
-* getBasePath()
 * getQuery() <small>(returns the full query string, e.g. `a=1&b=2`)</small>
 * getFragment()
-* getBaseUrl()
 
 You can get the query parameters as an associative array on the Request object using `getQueryParams()`.
 


### PR DESCRIPTION
getBasePath() & getBaseUrl are not part of the PSR-7 UriInterface. #555