### PR TITLE
Correction to HttpNotAllowedException

### DIFF
--- a/docs/v4/middleware/error-handling.md
+++ b/docs/v4/middleware/error-handling.md
@@ -222,7 +222,7 @@ The base class `HttpSpecializedException` extends `Exception` and comes with the
 * HttpBadRequestException
 * HttpForbiddenException
 * HttpInternalServerErrorException
-* HttpNotAllowedException
+* HttpMethodNotAllowedException
 * HttpNotFoundException
 * HttpNotImplementedException
 * HttpUnauthorizedException


### PR DESCRIPTION
There is no exception class in Slim named `HttpNotAllowedException`, It should be `HttpMethodNotAllowedException`