### PR TITLE
Fix copy-paste error from Slim v3

### DIFF
--- a/docs/v4/concepts/middleware.md
+++ b/docs/v4/concepts/middleware.md
@@ -17,8 +17,8 @@ A middleware implements the [PSR-15 Middleware Interface](https://www.php-fig.or
 
 It can do whatever is appropriate with these objects. The only hard requirement
 is that a middleware **MUST** return an instance of  `Psr\Http\Message\ResponseInterface`.
-Each middleware **SHOULD** invoke the next middleware and pass it Request and
-Response objects as arguments.
+Each middleware **SHOULD** invoke the next middleware and pass it the Request 
+object as argument.
 
 ## How does middleware work?
 


### PR DESCRIPTION
As of v4, a Middleware has to invoke the next Middleware by calling `$handler->handle($request)`. The response object is not passed as parameter anymore.