### PR TITLE
Update ContentLengthMiddleware placement

### DIFF
--- a/docs/v4/middleware/content-length.md
+++ b/docs/v4/middleware/content-length.md
@@ -2,7 +2,7 @@
 title: Content Length Middleware
 ---
 
-The Content Length Middleware will automatically append a `Content-Length` header to the response. This is to replace the `addContentLengthHeader` setting that was removed from Slim 3. This middleware should be placed on the center of the middleware stack so it gets executed last.
+The Content Length Middleware will automatically append a `Content-Length` header to the response. This is to replace the `addContentLengthHeader` setting that was removed from Slim 3. This middleware should be placed on the end of the middleware stack so that it gets executed first and exited last.
 
 ## Usage
 ```php
@@ -13,6 +13,8 @@ use Slim\Middleware\ContentLengthMiddleware;
 require __DIR__ . '/../vendor/autoload.php';
 
 $app = AppFactory::create();
+
+// Add any middleware which may modify the response body before adding the ContentLengthMiddleware
 
 $contentLengthMiddleware = new ContentLengthMiddleware();
 $app->add($contentLengthMiddleware);


### PR DESCRIPTION
When placed on the beginning of the middleware stack the `ContentLengthMiddleware` is executed last.

If other middleware later in the stack (executed earlier) modifies the response body after calling `$response = $handler->handle($request);` the modification will effectively occur after the `Content-Length` header is supplied. This results in a mismatch between the header value and the actual content length.

As discussed [here](https://discourse.slimframework.com/t/position-of-content-length-in-middleware-stack/4248) and [here](https://discourse.slimframework.com/t/slim-4-content-length-middleware-position/3740/5) the `ContentLengthMiddleware` should be executed first to avoid mismatches.