### PR TITLE
Fix Doc Block Type

### DIFF
--- a/docs/v4/concepts/middleware.md
+++ b/docs/v4/concepts/middleware.md
@@ -65,7 +65,7 @@ $app = AppFactory::create();
 /**
  * Example middleware closure
  *
- * @param  ServerRequest  $request PSR-7 request
+ * @param  Request        $request PSR-7 request
  * @param  RequestHandler $handler PSR-15 request handler
  *
  * @return Response
@@ -109,7 +109,7 @@ class ExampleBeforeMiddleware
     /**
      * Example middleware invokable class
      *
-     * @param  ServerRequest  $request PSR-7 request
+     * @param  Request        $request PSR-7 request
      * @param  RequestHandler $handler PSR-15 request handler
      *
      * @return Response
@@ -138,7 +138,7 @@ class ExampleAfterMiddleware
     /**
      * Example middleware invokable class
      *
-     * @param  ServerRequest  $request PSR-7 request
+     * @param  Request        $request PSR-7 request
      * @param  RequestHandler $handler PSR-15 request handler
      *
      * @return Response


### PR DESCRIPTION
My editor was giving me warnings about an incorrect type being used in `$handler->handle($request)`. This fixes the issue by using the correct type that is imported.