### PR TITLE
Update routing.md

### DIFF
--- a/docs/v4/objects/routing.md
+++ b/docs/v4/objects/routing.md
@@ -494,7 +494,7 @@ use Psr\Container\ContainerInterface;
 
 $container = $app->getContainer();
 
-$container->set('HomeController', function (ContainerInterface $container) {
+$container->set(\HomeController::class, function (ContainerInterface $container) {
     // retrieve the 'view' from the container
     $view = $container->get('view');
     


### PR DESCRIPTION
Use `\HomeController::class` instead of magic string 'HomeController' to be consistent with subsequent code snippets.