### PR TITLE
Update compose require to include doctrine/cache

### DIFF
--- a/docs/v4/cookbook/database-doctrine.md
+++ b/docs/v4/cookbook/database-doctrine.md
@@ -9,7 +9,7 @@ This cookbook entry describes how to integrate the widely used [Doctrine ORM](ht
 The first step is importing the Doctrine ORM into your project using [composer](https://getcomposer.org/).
 
 ```bash
-composer require doctrine/orm symfony/cache
+composer require doctrine/orm symfony/cache doctrine/cache
 ```
 
 Note that on April 30th 2021 Doctrine officially deprecated `doctrine/cache` when it released version v2.0.0, which deleted all cache implementations from that library.


### PR DESCRIPTION
This is because it's used below in the addition to the `dependencies.php`.

I see that `doctrine/cache` should be removed, if so, we should update this page accordingly.