### PR TITLE
Remove Newsletter Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,26 +143,3 @@ $app-&gt;run();</code></pre>
     </div>
 </div>
 
-<div class="row section">
-    <div class="col-md-12">
-        <h1 class="divider front-page-divider"><span>Newsletter</span></h1>
-        <p>
-            Join our newsletter and receive Slim Framework news, release announcements, and security updates.
-            This is a very very low traffic list. 
-            We hate spam, and we'll respect your inbox. You can unsubscribe at any time.
-        </p>
-        <form action="https://tinyletter.com/slimphp" method="post" target="_blank">
-            <div class="form-group">
-                <label for="tlemail">Enter your email address</label>
-                <input type="email" class="form-control" name="email" id="tlemail" required/>
-            </div>
-            <p class="center">
-                <input type="hidden" value="1" name="embed"/>
-                <input type="submit" class="btn btn-primary btn-lg" value="Subscribe Now"/>
-            </p>
-            <p class="center">
-                <small><a href="https://tinyletter.com/slimphp" target="_blank"><i class="fa fa-envelope"></i> Email Archives</a></small>
-            </p>
-        </form>
-    </div>
-</div>


### PR DESCRIPTION
It looks like TinyLetter has been replaced by Mailchimp. This PR removes the Newsletter section from the website.

![image](https://github.com/slimphp/Slim-Website/assets/781074/5f57b126-242c-4ef5-90aa-96ff67aca6da)
