### PR TITLE
Fix documentation quoting for Atlas installation commands

### DIFF
--- a/docs/v3/cookbook/database-atlas.md
+++ b/docs/v3/cookbook/database-atlas.md
@@ -12,8 +12,8 @@ Install Atlas using Composer. The ORM and CLI packages are delivered separately,
 since you are likely to need the command line tooling only in development:
 
 ```
-composer require atlas/orm ~3.0
-composer require --dev atlas/cli ~2.0
+composer require atlas/orm "~3.0"
+composer require --dev atlas/cli "~2.0"
 ```
 
 > **Note:**


### PR DESCRIPTION
Replaces unquoted Composer version constraints with quoted ones for both atlas/orm and atlas/cli to ensure consistent and valid command usage.