### PR TITLE
Add missing Exceptions

### DIFF
--- a/docs/v4/middleware/error-handling.md
+++ b/docs/v4/middleware/error-handling.md
@@ -252,10 +252,12 @@ The base class `HttpSpecializedException` extends `Exception` and comes with the
 
 * HttpBadRequestException
 * HttpForbiddenException
+* HttpGoneException
 * HttpInternalServerErrorException
 * HttpMethodNotAllowedException
 * HttpNotFoundException
 * HttpNotImplementedException
+* HttpTooManyRequestsException
 * HttpUnauthorizedException
 
 You can extend the `HttpSpecializedException` class if they need any other response codes that we decide not to provide with the base repository. 


### PR DESCRIPTION
This PR adds two missing exceptions to the "Error Handling" documentation page.

- Added `HttpGoneException`
- Added `HttpTooManyRequestsException`

These exceptions were previously missing from the middleware documentation, and adding them will help developers understand the full range of error handling capabilities in Slim 4.