### PR TITLE
Add a Docker-based local dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules
 npm-debug.log
 package-lock.json
 _site
+.jekyll-cache
+.jekyll-metadata
 .DS_Store
 /.idea/
 /.vscode/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,4 +311,4 @@ DEPENDENCIES
   webrick (~> 1.9)
 
 BUNDLED WITH
-   2.0.1
+   2.5.22

--- a/README.md
+++ b/README.md
@@ -6,17 +6,50 @@ This is the repository for the Slim website ([slimframework.com][slimframework-u
 
 If you spot any errors, typos, or missing information, please submit [a pull request][pr-url].
 
-### The documentation style guide
+## The documentation style guide
 
 Unless otherwise stated, the documentation follows [the AP Stylebook][ap-stylebook-url].
 
-### Are you a Microsoft Windows user
+## Run locally to test your changes
 
-You need to make sure you have [Ruby Devkit Installed (MSYS2)](https://rubyinstaller.org/add-ons/devkit.html).
+When making changes, it's helpful to run the site locally so you can see the changes or
+read your new works within the context of the site.
 
-### Building and running the documentation locally
+### Developing with Docker
 
-To run this site locally so that you can test your changes:
+If you would rather not install Ruby and the gem toolchain on your machine,
+you can run the site in a container instead. All you need is [Docker]
+[docker-url].
+
+From the repository root, start the site:
+
+```bash
+$ docker compose up
+```
+
+The first run installs the gems into a cached volume and takes a few minutes;
+later runs start in seconds. Once Jekyll reports `Server running...`, browse
+to http://localhost:4000.
+
+The site rebuilds automatically as you edit files, and the browser refreshes
+via LiveReload. Press `Ctrl-C` to stop the server; run `docker compose down`
+afterwards if you also want to remove the container.
+
+To run a one-off command in the same environment, such as a production build,
+use `docker compose run`:
+
+```bash
+$ docker compose run --rm jekyll bundle exec jekyll build
+```
+
+
+### Developing directly on your local computer
+
+You can also run this site directly on your local computer to test your changes.
+
+Firstly, ensure you have Ruby installed. If you are a Microsoft Windows user, you
+need to make sure you have [Ruby Devkit Installed (MSYS2)](https://rubyinstaller.org/add-ons/devkit.html).
+
 
 ```bash
 $ sudo gem install bundler
@@ -31,7 +64,7 @@ $ bundle exec jekyll serve
 
 Then, browse to http://localhost:4000 in your browser of choice.
 
-#### Editing the site's CSS
+## Editing the site's CSS
 
 The CSS uses Less and is managed by `grunt`.
 
@@ -50,11 +83,32 @@ grunt
 
 You can also run `grunt watch` to automatically rebuild when you make CSS changes.
 
+If you would rather not install NodeJS and grunt on your machine, the
+`docker-compose.yml` includes a `css` service that runs the same toolchain
+in a container. To start `grunt watch`:
+
+```bash
+$ docker compose up css
+```
+
+For a one-off build, run:
+
+```bash
+$ docker compose run --rm css npx grunt
+```
+
+The first run installs the npm packages into a cached volume; later runs
+start almost instantly.
+
 ### Build instructions for deployment
 
 ```bash
 bundle exec jekyll build
 ```
+
+Merging a pull request to the `gh-pages` branch will trigger a GitHub Action
+that builds and deploys the site to GitHub Pages.
+
 
 ### Update the Algolia search database
 
@@ -67,6 +121,7 @@ bundle exec jekyll algolia
 ```
 
 [ap-stylebook-url]: https://www.apstylebook.com
+[docker-url]: https://docs.docker.com/get-docker/
 [jekyll-url]: https://jekyllrb.com
 [pr-url]: https://github.com/slimphp/Slim-Website/compare
 [slimframework-url]: https://slimframework.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+# Local preview of the Slim website with Jekyll — no Ruby needed on the host.
+#   Start:  docker compose up
+#   View:   http://localhost:4000
+#   Stop:   Ctrl-C   (then optionally: docker compose down)
+services:
+  jekyll:
+    image: ruby:3.3
+    working_dir: /site
+    environment:
+      # Always use the bundler shipped in the image, whatever the
+      # `BUNDLED WITH` pin in Gemfile.lock happens to be.
+      BUNDLE_VERSION: system
+      # Never rewrite Gemfile.lock from inside the container.
+      BUNDLE_FROZEN: "true"
+    command: >
+      bash -c "bundle install &&
+      bundle exec jekyll serve --host 0.0.0.0 --livereload --force_polling"
+    ports:
+      - "4000:4000"    # site
+      - "35729:35729"  # livereload
+    volumes:
+      - .:/site                 # the repo, live-mounted
+      - gems:/usr/local/bundle  # installed gems, cached between runs
+
+  # CSS toolchain (Less + grunt). Opt-in — not started by `docker compose up`.
+  #   Watch:    docker compose up css
+  #   One-off:  docker compose run --rm css npx grunt
+  css:
+    profiles: ["css"]
+    image: node:22
+    working_dir: /site
+    # Always ensure npm packages are installed before running the command.
+    entrypoint: ["sh", "-c", "npm install --silent --no-audit --no-fund && exec \"$$@\"", "--"]
+    command: ["npx", "grunt", "watch"]
+    volumes:
+      - .:/site
+      - css_node_modules:/site/node_modules  # npm packages, cached between runs
+
+volumes:
+  gems:
+  css_node_modules:


### PR DESCRIPTION
Provide a `docker-compose.yml` so contributors can work on the site without installing Ruby, NodeJS and the dependencies locally. Update README to document it.

Also, bump the Gemfile.lock bundler pin to match a current Bundler release.
