### PR TITLE
Escape post titles in the blog RSS feed

### DIFF
--- a/blog/feed.rss
+++ b/blog/feed.rss
@@ -14,7 +14,7 @@ layout: blank
         <webMaster>hello@joshlockhart.com</webMaster>
         {% for post in site.posts limit:10 %}
         <item>
-            <title>{{ post.title }}</title>
+            <title>{{ post.title | xml_escape }}</title>
             <link>{{ site.url }}{{ post.url }}</link>
             <description>
                 <![CDATA[


### PR DESCRIPTION
Run post titles through the xml_escape Liquid filter so that characters like <, > and & are encoded as entities to avoid invalid RSS.
